### PR TITLE
bug/EnvironmentNotSetInRollback while doing rollback migration enviro…

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -246,6 +246,7 @@ class Manager
                 $className = $revision->getName();
                 
                 $migration = new $className($this->getClient($environment));
+                $migration->setEnvironment($environment);
                 $migration->down();
                 
                 $this->logDown($revision->getId(), $environment);


### PR DESCRIPTION
…nment property was not set, thus in down() method empty environment was returned